### PR TITLE
get memory units from environment variable

### DIFF
--- a/farmpy/tests/lsf_test.py
+++ b/farmpy/tests/lsf_test.py
@@ -32,6 +32,13 @@ class TestJob(unittest.TestCase):
         bsub._set_memory_units()
         self.assertEqual('KB', bsub.memory_units)
 
+        os.environ['FARMPY_LSF_MEMORY_UNITS'] = 'MB'
+        bsub = lsf.Job('out', 'error', 'name', 'queue', 1, 'cmd')
+        bsub._lsadmin_cmd = 'cat ' + os.path.join(test_dir, 'lsf_unittest_lsadmin_showconf_kb.txt')
+        bsub._set_memory_units()
+        self.assertEqual('MB', bsub.memory_units)
+        del os.environ['FARMPY_LSF_MEMORY_UNITS']
+
         bsub = lsf.Job('out', 'error', 'name', 'queue', 1, 'cmd')
         bsub._lsadmin_cmd = 'cat ' + os.path.join(test_dir, 'lsf_unittest_lsadmin_showconf_kb.txt')
         bsub._set_memory_units()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='farmpy',
-    version='0.41.0',
+    version='0.42.0',
     description='Package to run farm jobs - currently LSF supported',
     author='Martin Hunt',
     author_email='mh12@sanger.ac.uk',


### PR DESCRIPTION
It gets the memory units (which can be KB or MB depending on the LSF setup) by running `lsadmin showconf`).

This changes the behaviour to use the environment variable `FARMPY_LSF_MEMORY_UNITS` instead, if it is set, avoiding trying to run `lsadmin showconf`.